### PR TITLE
Update ibw-extractor.py

### DIFF
--- a/ibw-extractor.py
+++ b/ibw-extractor.py
@@ -46,7 +46,7 @@ def main(infiles, outfile, outformat, outdir,
         infiles = util.flatten(map(list_ibw, infiles))
 
     # Check for errors
-    if len(infiles) is 0:
+    if len(infiles) == 0:
         click.secho("No .ibw files found", fg="red")
         sys.exit(1)
     if len(infiles) > 1 and outfile:


### PR DESCRIPTION
python 3.10 complains:

/tmp/ibw/ibw-extractor/ibw-extractor.py:49: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(infiles) is 0:


This fixes this.